### PR TITLE
[wip] install postgres contrib packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/do
 RUN chmod +x /usr/local/bin/gosu
 
 RUN apk-install "postgresql"
+RUN apk-install "postgresql-contrib"
 
 ENV POSTGRES_USERNAME postgres
 ENV POSTGRES_PASSWORD password


### PR DESCRIPTION
I have a project where I'm trying to use the `uuid-ossp` extension, but despite adding this to the Docker build (and confirming I'm using that image) I still get:

```
postgres | STATEMENT:  CREATE EXTENSION "uuid-ossp"
main     | Error: Sequel::DatabaseError: PG::UndefinedFile: ERROR:  could not open extension control file "/usr/share/postgresql/extension/uuid-ossp.control": No such file or directory
```
