### PR TITLE
Update Alpine from 3.2 to 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM gliderlabs/alpine:3.2
+FROM gliderlabs/alpine:3.4
 
-RUN apk-install curl
+RUN apk add --no-cache curl postgresql postgresql-contrib
 
 RUN curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64"
 RUN chmod +x /usr/local/bin/gosu
-
-RUN apk-install "postgresql"
-RUN apk-install "postgresql-contrib"
 
 ENV POSTGRES_USERNAME postgres
 ENV POSTGRES_PASSWORD password
@@ -22,6 +19,8 @@ ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /
+
+RUN apk del curl
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 


### PR DESCRIPTION
3.4 supports (among various bugfixes) — `apk add --no-cache`, postgres 9.5
