### PR TITLE
Added HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,12 @@ ENV PGDATA /var/lib/postgresql/data
 VOLUME /var/lib/postgresql/data
 
 COPY docker-entrypoint.sh /
+COPY docker-healthcheck.sh /
 
 RUN apk del curl
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
+HEALTHCHECK --interval=1s --retries=30 CMD ["/docker-healthcheck.sh"]
 
 EXPOSE 5432
 CMD ["postgres"]

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+psql -h "localhost" -U "postgres" -c '\l'
+ret_code=$?
+
+# Docker healthcheck requires we only over exit 0 or 1 so this captures the
+# other exit codes and coverts them all to a simple exit 1
+if [ $ret_code != 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
This functionality was added in `Docker 1.12`, it allows us to wait for postgres to startup correctly before any other containers that are linked.

Let me know if you require any stylistic changes, I'm not usually one for writing many bash scripts :)

/cc @awsmsrc 
