### PR TITLE
Add support for access through a Docker network

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,7 @@ if [ -z "$(ls -A "$PGDATA")" ]; then
     echo
 
     { echo; echo "host all all 0.0.0.0/0 $authMethod"; } >> "$PGDATA"/pg_hba.conf
+    { echo; echo "host all all 172.16.0.0/12 $authMethod"; } >> "$PGDATA"/pg_hba.conf
 fi
 
 exec gosu postgres "$@"


### PR DESCRIPTION
When connecting your container to a local Docker network, you need this line to provide access to Postgres.